### PR TITLE
Avoid negative scissor offset

### DIFF
--- a/src/core/java/graphics/cinnabar/core/b3d/renderpass/CinnabarRenderPass.java
+++ b/src/core/java/graphics/cinnabar/core/b3d/renderpass/CinnabarRenderPass.java
@@ -292,8 +292,12 @@ public class CinnabarRenderPass implements CVKRenderPass {
         try (final var stack = memoryStack.push()) {
             scissorState.enable(x, y, width, height);
             final var scissor = VkRect2D.calloc(1, stack);
-            scissor.offset().set(x, y);
-            scissor.extent().set(width, height);
+            // sometimes negative, but must be >= 0
+            scissor.offset().set(Math.max(x, 0), Math.max(y, 0));
+            // adjust if x or y is negative
+            width -= Math.max(-x, 0);
+            height -= Math.max(-y, 0);
+            scissor.extent().set(Math.max(width, 0), Math.max(height, 0));
             vkCmdSetScissor(commandBuffer, 0, scissor);
         }
     }


### PR DESCRIPTION
Getting this error when trying to open resourcepacks screen
<details>
  <summary>Error</summary>  

  ```bash
  [21:58:18] [Render thread/WARN] [gr.ci.li.CinnabarLib/]: VALIDATION ERROR : vkCmdSetScissor(): pScissors[0].offset.x (-4) is negative.
  The Vulkan spec states: The x and y members of offset member of any element of pScissors must be greater than or equal to 0 (https://docs.vulkan.org/spec/latest/chapters/fragops.html#VUID-vkCmdSetScissor-x-00595)
  [21:58:18] [Render thread/WARN] [gr.ci.li.CinnabarLib/]: graphics.cinnabar.api.exceptions.VkException
          at TRANSFORMER/cinnabar@0.0.5/graphics.cinnabar.lib.vulkan.VulkanDebug.invoke(VulkanDebug.java:83)
          at MC-BOOTSTRAP/org.lwjgl.vulkan@3.3.3+5/org.lwjgl.vulkan.VkDebugUtilsMessengerCallbackEXTI.callback(VkDebugUtilsMessengerCallbackEXTI.java:58)
          at MC-BOOTSTRAP/org.lwjgl@3.3.3+5/org.lwjgl.system.JNI.callPPV(Native Method)
          at MC-BOOTSTRAP/org.lwjgl.vulkan@3.3.3+5/org.lwjgl.vulkan.VK10.nvkCmdSetScissor(VK10.java:10376)
          at MC-BOOTSTRAP/org.lwjgl.vulkan@3.3.3+5/org.lwjgl.vulkan.VK10.vkCmdSetScissor(VK10.java:10445)
          at TRANSFORMER/cinnabar@0.0.5/graphics.cinnabar.core.b3d.renderpass.CinnabarRenderPass.enableScissor(CinnabarRenderPass.java:325)
          at TRANSFORMER/minecraft@1.21.8/net.minecraft.client.gui.render.GuiRenderer.enableScissor(GuiRenderer.java:685)
          at TRANSFORMER/minecraft@1.21.8/net.minecraft.client.gui.render.GuiRenderer.executeDraw(GuiRenderer.java:644)
          at TRANSFORMER/minecraft@1.21.8/net.minecraft.client.gui.render.GuiRenderer.executeDrawRange(GuiRenderer.java:274)
          at TRANSFORMER/minecraft@1.21.8/net.minecraft.client.gui.render.GuiRenderer.draw(GuiRenderer.java:235)
          at TRANSFORMER/minecraft@1.21.8/net.minecraft.client.gui.render.GuiRenderer.render(GuiRenderer.java:143)
          at TRANSFORMER/minecraft@1.21.8/net.minecraft.client.renderer.GameRenderer.render(GameRenderer.java:560)
          at TRANSFORMER/minecraft@1.21.8/net.minecraft.client.Minecraft.runTick(Minecraft.java:1291)
          at TRANSFORMER/minecraft@1.21.8/net.minecraft.client.Minecraft.run(Minecraft.java:888)
          at TRANSFORMER/minecraft@1.21.8/net.minecraft.client.main.Main.main(Main.java:243)
          at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
          at java.base/java.lang.reflect.Method.invoke(Method.java:580)
          at MC-BOOTSTRAP/fml_loader@9.0.16/net.neoforged.fml.loading.targets.CommonLaunchHandler.runTarget(CommonLaunchHandler.java:132)
          at MC-BOOTSTRAP/fml_loader@9.0.16/net.neoforged.fml.loading.targets.CommonLaunchHandler.clientService(CommonLaunchHandler.java:120)
          at MC-BOOTSTRAP/fml_loader@9.0.16/net.neoforged.fml.loading.targets.NeoForgeClientDevLaunchHandler.runService(NeoForgeClientDevLaunchHandler.java:49)
          at MC-BOOTSTRAP/fml_loader@9.0.16/net.neoforged.fml.loading.targets.CommonLaunchHandler.lambda$launchService$4(CommonLaunchHandler.java:114)
          at MC-BOOTSTRAP/fml_loader@9.0.16/cpw.mods.modlauncher.LaunchServiceHandlerDecorator.launch(LaunchServiceHandlerDecorator.java:25)
          at MC-BOOTSTRAP/fml_loader@9.0.16/cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:55)
          at MC-BOOTSTRAP/fml_loader@9.0.16/cpw.mods.modlauncher.LaunchServiceHandler.launch(LaunchServiceHandler.java:73)
          at MC-BOOTSTRAP/fml_loader@9.0.16/cpw.mods.modlauncher.Launcher.run(Launcher.java:104)
          at MC-BOOTSTRAP/fml_loader@9.0.16/cpw.mods.modlauncher.Launcher.main(Launcher.java:75)
          at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
          at java.base/java.lang.reflect.Method.invoke(Method.java:580)
          at cpw.mods.bootstraplauncher/cpw.mods.bootstraplauncher.BootstrapLauncher.run(BootstrapLauncher.java:203)
          at cpw.mods.bootstraplauncher/cpw.mods.bootstraplauncher.BootstrapLauncher.main(BootstrapLauncher.java:62)
          at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
          at java.base/java.lang.reflect.Method.invoke(Method.java:580)
          at net.neoforged.devlaunch.Main.main(Main.java:57)
  ```  
</details>