### PR TITLE
Add preliminary support for Longview

### DIFF
--- a/src/core/java/graphics/cinnabar/core/hg3d/Hg3D.java
+++ b/src/core/java/graphics/cinnabar/core/hg3d/Hg3D.java
@@ -8,4 +8,5 @@ public class Hg3D {
     public static final Logger HG3D_LOG = LogUtils.getLogger();
     public static final boolean TRACE_LOGGING = Hg.traceLogging();
     public static final boolean DEBUG_LOGGING = Hg.debugLogging() || TRACE_LOGGING;
+    public static final boolean USE_REVERSE_Z = Hg3D.class.getClassLoader().getResource("page/langeweile/longview/api/LongviewDevice.class") != null;
 }

--- a/src/core/java/graphics/cinnabar/core/hg3d/Hg3DCommandEncoder.java
+++ b/src/core/java/graphics/cinnabar/core/hg3d/Hg3DCommandEncoder.java
@@ -279,7 +279,7 @@ public class Hg3DCommandEncoder implements C3DCommandEncoder, Hg3DObject, Destro
         final var cb = mainCommandBuffer();
         cb.barrier();
         cb.clearColorImage(((Hg3DGpuTexture) colorTexture).image().resourceRange(), clearColor);
-        cb.clearDepthStencilImage(((Hg3DGpuTexture) depthTexture).image().resourceRange(), clearDepth, -1);
+        cb.clearDepthStencilImage(((Hg3DGpuTexture) depthTexture).image().resourceRange(), Hg3D.USE_REVERSE_Z ? 1.0 - clearDepth : clearDepth, Hg3D.USE_REVERSE_Z ? 1 : -1);
     }
     
     @Override
@@ -300,7 +300,7 @@ public class Hg3DCommandEncoder implements C3DCommandEncoder, Hg3DObject, Destro
         assert depthTexture instanceof Hg3DGpuTexture;
         final var cb = mainCommandBuffer();
         cb.barrier();
-        cb.clearDepthStencilImage(((Hg3DGpuTexture) depthTexture).image().resourceRange(), clearDepth, -1);
+        cb.clearDepthStencilImage(((Hg3DGpuTexture) depthTexture).image().resourceRange(), Hg3D.USE_REVERSE_Z ? 1.0 - clearDepth : clearDepth, Hg3D.USE_REVERSE_Z ? 1 : -1);
     }
     
     // Neo

--- a/src/core/java/graphics/cinnabar/core/hg3d/Hg3DGpuDevice.java
+++ b/src/core/java/graphics/cinnabar/core/hg3d/Hg3DGpuDevice.java
@@ -462,4 +462,8 @@ public class Hg3DGpuDevice implements C3DGpuDevice {
     public boolean isZZeroToOne() {
         return true;
     }
+
+    public boolean supportsReverseZ() {
+        return Hg3D.USE_REVERSE_Z;
+    }
 }

--- a/src/core/java/graphics/cinnabar/core/hg3d/Hg3DRenderPipeline.java
+++ b/src/core/java/graphics/cinnabar/core/hg3d/Hg3DRenderPipeline.java
@@ -127,9 +127,9 @@ public class Hg3DRenderPipeline implements Hg3DObject, CompiledRenderPipeline, D
             depthTest = new HgGraphicsPipeline.DepthTest(switch (pipeline.getDepthTestFunction()) {
                 case NO_DEPTH_TEST -> HgCompareOp.ALWAYS;
                 case EQUAL_DEPTH_TEST -> HgCompareOp.EQUAL;
-                case LEQUAL_DEPTH_TEST -> HgCompareOp.LESS_OR_EQUAL;
-                case LESS_DEPTH_TEST -> HgCompareOp.LESS;
-                case GREATER_DEPTH_TEST -> HgCompareOp.GREATER;
+                case LEQUAL_DEPTH_TEST -> Hg3D.USE_REVERSE_Z ? HgCompareOp.GREATER_OR_EQUAL : HgCompareOp.LESS_OR_EQUAL;
+                case LESS_DEPTH_TEST -> Hg3D.USE_REVERSE_Z ? HgCompareOp.GREATER : HgCompareOp.LESS;
+                case GREATER_DEPTH_TEST -> Hg3D.USE_REVERSE_Z ? HgCompareOp.LESS : HgCompareOp.GREATER;
             }, pipeline.isWriteDepth());
         } else {
             depthTest = null;

--- a/src/core/java/graphics/cinnabar/core/profiling/ProfilingGpuDevice.java
+++ b/src/core/java/graphics/cinnabar/core/profiling/ProfilingGpuDevice.java
@@ -8,6 +8,7 @@ import com.mojang.blaze3d.systems.CommandEncoderBackend;
 import com.mojang.blaze3d.systems.GpuDeviceBackend;
 import com.mojang.blaze3d.textures.*;
 import com.mojang.jtracy.TracyClient;
+import graphics.cinnabar.core.hg3d.Hg3D;
 import org.jspecify.annotations.Nullable;
 
 import java.nio.ByteBuffer;
@@ -172,5 +173,10 @@ public class ProfilingGpuDevice implements GpuDeviceBackend {
     @Override
     public boolean isZZeroToOne() {
         return realDevice.isZZeroToOne();
+    }
+
+    // FIXME - Somehow get realDevice.supportsReverseZ()Z
+    public boolean supportsReverseZ() {
+        return Hg3D.USE_REVERSE_Z;
     }
 }


### PR DESCRIPTION
This is based on code that I have written for Longview 0.2.0, although I want to wait until all possible rough edges involving compatibility with different backends are smoothed out.

Anyway, this adds support for Reverse Z when Longview is installed, letting it handle the abstract bits (currently the ProjectionMixin) while Cinnarbar does the backend-specific bits itself. And when Longview isn't installed? Cinnabar will still work! It just won't be using reverse Z anymore.

Things known to be broken:
- Lack of patching of post/transparency.fsh
  - This will break ~~glowing signs~~ and the Improved Transparency mode
  - (EDIT: glowing sign issue actually caused by not flipping the depth biases)

I'm making this PR so that any possible trouble can be sorted out before I release Longview 0.2.0